### PR TITLE
fix: force to calfile when necessary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^docs/conf.py|^tests/data/*'
+exclude: '^docs/conf.py|^tests/data/'
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/src/edges_analysis/analysis/averaging.py
+++ b/src/edges_analysis/analysis/averaging.py
@@ -326,7 +326,7 @@ def bin_gha_unbiased_regular(
     weights: np.ndarray,
     gha: np.ndarray,
     bins: np.ndarray,
-) -> [np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Bin data in an unbiased way using a model fit.
 

--- a/src/edges_analysis/analysis/calibrate.py
+++ b/src/edges_analysis/analysis/calibrate.py
@@ -130,7 +130,13 @@ class LabCalibration:
         else:
             ant_s11 = self.antenna_s11_model(freq)
 
-        return self.calobs.calibrate_Q(freq, q, ant_s11)
+        c = (
+            self.calobs
+            if isinstance(self.calobs, Calibration)
+            else self.calobs.to_calfile()
+        )
+
+        return c.calibrate_Q(freq, q, ant_s11)
 
     def calibrate_temp(
         self, temp: np.ndarray, freq: Optional[np.ndarray] = None


### PR DESCRIPTION
This forces the underlying calibration observation to a calfile when necessary to use it for the API.