### PR TITLE
filtering based on power levels at 150 MHz

### DIFF
--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -998,3 +998,17 @@ def negative_power_filter(*, data: CalibratedData):
     These integrations obviously have some weird stuff going on.
     """
     return np.array([np.any(spec <= 0) for spec in data.spectrum])
+
+
+@step_filter(axis="time", data_type=(RawData))
+def filter_150mhz(*, data: RawData, d150: int):
+    """The time stamps where d <= d150 only is included."""
+    freq_mask = (RawData.raw_frequencies - 153.5) <= 1.5
+    rms = np.sqrt(np.mean(RawData.spectrum[:, freq_mask] ** 2))
+
+    freq_mask2 = (RawData.raw_frequencies - 157.0) <= 1.5
+    av = np.mean(RawData.spectrum[:, freq_mask2])
+    d = 200.0 * np.sqrt(rms) / av
+
+    flags = d >= d150
+    return flags

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -60,3 +60,8 @@ def test_rms_filter(cal_step):
 def test_negpower_filter(cal_step):
     out_flags = filters.negative_power_filter(data=cal_step)
     assert len(out_flags) == 2
+
+
+def test_150mhz_filter(cal_step):
+    out_flags = filters.filter_150mhz(data=cal_step, threshold=1)
+    assert len(out_flags) == 2


### PR DESCRIPTION
This function is from Alan's section of code:
```c
if(d150 < 1e6) {
                    av = a = 0.0;
                for(i=0;i<j;i++) {
                    if(fabs(fstart + i*fstep - 153.5) < 1.5) {av += data[i]; a++;}
                }
                    rms = 0; av = av/a;
                    for(i=0;i<j;i++) {
                    if(fabs(fstart + i*fstep - 153.5) < 1.5) {
                    rms += (data[i]-av)*(data[i]-av);
                 }
                }
                    av = b = 0;
                    for(i=0;i<j;i++) {
                    if(fabs(fstart + i*fstep - 157.0) < 1.5) {
                    av += data[i];
                    b++;
                  }
                 }
                     d = 200.0*sqrt(rms/a)/(av/b);
                 if(d >= d150) printf("d150 %f %f\n",d,av/b);
                }
                printf("ppcercent %f, pkpwr %f , d %f, dload %f, rrmsf %f, fmpwr %f, j %d", ppercent, pkpwr, d, dload, rrmsf, fmpwr, j);
                if((ppercent < peakpwr && (ppercent > minpwr)) 
                          && ((pkpwr < pkpwrm) || (pkpwr > fabs(pkpwrm) && pkpwrm < 0)) 
                          && d <= d150 
                          && dload < dloadmax
                          && rrmsf < maxrmsf
                          && fmpwr < maxfm
                          && j == nspec){
                wttt = 1;

```
