### PR TITLE
filter that checks for orb power and peak power about 80 MHz

### DIFF
--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -1103,7 +1103,7 @@ def peak_orbcomm_filter(
     *,
     data: RawData | CalibratedData,
     threshold: float = 40.0,
-    mean_freq_range: tuple[float, float] | None = None,
+    mean_freq_range: tuple[float, float] | None = (80, 200),
 ):
     """
     Filters out whole integrations that have high power between (137, 138) MHz.

--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -1024,12 +1024,12 @@ def _peak_power_filter(
         The range of frequencies over which to take a mean to compare to the peak.
         By default, the same as the ``peak_freq_range``.
     """
-    if peak_freq_range[0] <= peak_freq_range[1]:
+    if peak_freq_range[0] >= peak_freq_range[1]:
         raise ValueError(
             f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
         )
 
-    if mean_freq_range[0] <= mean_freq_range[1]:
+    if mean_freq_range[0] >= mean_freq_range[1]:
         raise ValueError(
             f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
         )

--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -1126,6 +1126,7 @@ def peak_orbcomm_filter(
         mean_freq_range=mean_freq_range,
     )
 
+
 @step_filter(axis="time", data_type=(RawData, CalibratedData))
 def filter_150mhz(*, data: RawData | CalibratedData, threshold: float):
     """Filter based on power around 150 MHz.
@@ -1147,4 +1148,3 @@ def filter_150mhz(*, data: RawData | CalibratedData, threshold: float):
     d = 200.0 * np.sqrt(rms) / av
 
     return d > threshold
-

--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -125,9 +125,12 @@ def step_filter(
                     else:
                         return fnc(data=data, **kwargs)
 
-                this_flag = list(
-                    p_tqdm.p_map(fnc_, data, flg, unit="files", num_cpus=n_threads)
-                )
+                if n_threads > 1:
+                    this_flag = list(
+                        p_tqdm.p_map(fnc_, data, flg, unit="files", num_cpus=n_threads)
+                    )
+                else:
+                    this_flag = list(p_tqdm.t_map(fnc_, data, flg, unit="files"))
 
             if flags is not None and any(
                 np.any(f0 != f1) for f0, f1 in zip(flg, flags)

--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -1024,9 +1024,23 @@ def _peak_power_filter(
         The range of frequencies over which to take a mean to compare to the peak.
         By default, the same as the ``peak_freq_range``.
     """
+    if peak_freq_range[0] <= peak_freq_range[1]:
+        raise ValueError(
+            f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
+        )
+
+    if mean_freq_range[0] <= mean_freq_range[1]:
+        raise ValueError(
+            f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
+        )
+
     mask = (data.raw_frequencies > peak_freq_range[0]) & (
         data.raw_frequencies <= peak_freq_range[1]
     )
+
+    if not np.any(mask):
+        return np.zeros(len(data.spectrum), dtype=bool)
+
     spec = data.spectrum[:, mask]
     peak_power = spec.max(axis=1)
 
@@ -1034,6 +1048,9 @@ def _peak_power_filter(
         mask = (data.raw_frequencies > mean_freq_range[0]) & (
             data.raw_frequencies <= mean_freq_range[1]
         )
+        if not np.any(mask):
+            return np.zeros(len(data.spectrum), dtype=bool)
+
         spec = data.spectrum[:, mask]
 
     mean, _ = weighted_mean(

--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -1029,7 +1029,7 @@ def _peak_power_filter(
             f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
         )
 
-    if mean_freq_range[0] >= mean_freq_range[1]:
+    if mean_freq_range is not None and mean_freq_range[0] >= mean_freq_range[1]:
         raise ValueError(
             f"The frequency range of the peak must be non-zero, got {peak_freq_range}"
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -80,7 +80,7 @@ def test_peak_orbcomm_filter(cal_step):
     assert len(out_flags) == 2
     assert out_flags[0].shape == cal_step[0].spectrum.shape
 
+
 def test_150mhz_filter(cal_step):
     out_flags = filters.filter_150mhz(data=cal_step, threshold=1)
     assert len(out_flags) == 2
-

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -60,3 +60,15 @@ def test_rms_filter(cal_step):
 def test_negpower_filter(cal_step):
     out_flags = filters.negative_power_filter(data=cal_step)
     assert len(out_flags) == 2
+
+
+def test_peak_power_filter(cal_step):
+    out_flags = filters.peak_power_filter(data=cal_step)
+    assert len(out_flags) == 2
+    assert out_flags[0].shape == cal_step[0].spectrum.shape
+
+
+def test_peak_orbcomm_filter(cal_step):
+    out_flags = filters.peak_orbcomm_filter(data=cal_step)
+    assert len(out_flags) == 2
+    assert out_flags[0].shape == cal_step[0].spectrum.shape

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,7 @@
 import numpy as np
 from edges_analysis.analysis import filters
 from edges_cal import modelling as mdl
+import pytest
 
 
 def test_aux_filter():
@@ -66,6 +67,12 @@ def test_peak_power_filter(cal_step):
     out_flags = filters.peak_power_filter(data=cal_step)
     assert len(out_flags) == 2
     assert out_flags[0].shape == cal_step[0].spectrum.shape
+
+    with pytest.raises(ValueError):
+        filters.peak_power_filter(data=cal_step, peak_freq_range=(60, 60))
+
+    with pytest.raises(ValueError):
+        filters.peak_power_filter(data=cal_step, mean_freq_range=(61, 60))
 
 
 def test_peak_orbcomm_filter(cal_step):


### PR DESCRIPTION
Reference Code for this filter

```c
if(data[j] > pkpwr && fstart + j*fstep > 80.0) pkpwr = data[j];
 if(data[j] > orbpwr && fabs(fstart + j*fstep - 137.5) < 1.0) orbpwr = data[j];
a = b = 1e-99;
                for(i=0;i<j;i++) {
                      if(fabs(fstart + i*fstep - 137.9) < 0.02) orbpwr2 = data[i]-data[i+50];
                      if(data[i] > 0.0 && data[i] < pkpwr/10.0 && fstart + i*fstep > 80.0) {
                          a += data[i];
                          b++;
                       }
                }
                pkpwr = 10.0*log10(pkpwr / (a/b));
                orbpwr = 10.0*log10(orbpwr / (a/b));
                if(orbpwr > pkpwr) pkpwr = orbpwr;
                pkpwr = orbpwr;   // O.K. orbpwr and peak power sufficient for verystrong signals
                if(orbpwr2 > 0) orbpwr2 = 10.0*log10(orbpwr2 / (a/b));
//                if(orbpwr2 > 5.0) pkpwr = 10.0*orbpwr2;
                tempr = tempmon(fstart,fstep,avdata0);
```