### PR TITLE
feat: allow read_steep to not validate

### DIFF
--- a/src/edges_analysis/analysis/levels.py
+++ b/src/edges_analysis/analysis/levels.py
@@ -457,6 +457,7 @@ class _ReductionStep(HDF5Object):
 
 def read_step(
     fname: tp.PathLike | _ReductionStep | io.HDF5RawSpectrum,
+    validate: bool = True,
 ) -> _ReductionStep | io.HDF5RawSpectrum:
     """Read a filename as a processing reduction step.
 
@@ -469,7 +470,7 @@ def read_step(
     if fname.suffix == ".acq":
         return io.FieldSpectrum(fname).data
     else:
-        return get_step_type(fname)(fname)
+        return get_step_type(fname)(fname, validate=validate)
 
 
 def get_step_type(

--- a/src/edges_analysis/cli.py
+++ b/src/edges_analysis/cli.py
@@ -491,7 +491,7 @@ def filter(settings, path, nthreads, flag_idx, label, clobber):  # noqa: A001
     if len({p.parent for p in input_files}) != 1:
         raise ValueError("Your input files do not come from a single processing.")
 
-    input_data = [levels.read_step(fl) for fl in input_files]
+    input_data = [levels.read_step(fl, validate=False) for fl in input_files]
 
     # Save the settings file
     output_dir = input_files[0].parent
@@ -516,7 +516,7 @@ def filter(settings, path, nthreads, flag_idx, label, clobber):  # noqa: A001
                 shutil.copy(fl, output_dir / fl.name)
 
             input_files = [output_dir / fl.name for fl in input_files]
-            input_data = [levels.read_step(fl) for fl in input_files]
+            input_data = [levels.read_step(fl, validate=False) for fl in input_files]
         elif not (
             clobber
             or qs.confirm(


### PR DESCRIPTION
This just updates `read_step` to make it optional to validate the HDF5Object. It is also now default not to check it in the CLI. Not sure if that's a good long-term idea though..