### PR TITLE
fix the axis to be masked when it is working on gridded/combined data

### DIFF
--- a/src/edges_analysis/analysis/filters.py
+++ b/src/edges_analysis/analysis/filters.py
@@ -909,7 +909,7 @@ def _rfi_filter_factory(method: str):
         mask = (data.raw_frequencies >= freq_range[0]) & (
             data.raw_frequencies <= freq_range[1]
         )
-        
+
         out_flags = tools.run_xrfi(
             method=method,
             spectrum=data.spectrum[..., mask],


### PR DESCRIPTION
In the way the code was written: When XRFI_model is working on combined/gridded data, the mask array is working on the day axis. 

Again, this could be considered a quick fix. If you have a suggestion for a smarter implementation, I'd take that. 