### PR TITLE
perf: release memory from HDF5 objects manually

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     rich
     attrs
     questionary
+    psutil
 
 [options.packages.find]
 where = src

--- a/src/edges_analysis/analysis/levels.py
+++ b/src/edges_analysis/analysis/levels.py
@@ -572,6 +572,10 @@ class _SingleDayMixin:
         return self.raw_data.meta["hour"]
 
     @property
+    def minute(self):
+        return self.raw_data.meta["minute"]
+
+    @property
     def gha(self):
         return self.raw_data.ancillary["gha"]
 
@@ -582,7 +586,7 @@ class _SingleDayMixin:
     @property
     def datestring(self):
         """The date this observation was started, as a string."""
-        return f"{self.year:04}-{self.day:03}-{self.hour:02}"
+        return f"{self.year:04}-{self.day:03}-{self.hour:02}-{self.minute:02}"
 
     @property
     def raw_time_data(self):
@@ -1092,6 +1096,7 @@ class RawData(_ReductionStep, _SingleDayMixin):
             "year": times[0].year,
             "day": get_jd(times[0]),
             "hour": times[0].hour,
+            "minute": times[0].minute,
             **prev_step["meta"],
         }
 

--- a/src/edges_analysis/cli.py
+++ b/src/edges_analysis/cli.py
@@ -1,9 +1,9 @@
 """CLI routines for edges-analysis."""
+from __future__ import annotations
 import glob
 import logging
 import sys
 from pathlib import Path
-from typing import List, Type, Optional
 import shutil
 import time
 import os
@@ -90,7 +90,7 @@ def _ctx_to_dct(args):
     return dct
 
 
-def _get_files(pth: Path, filt=h5py.is_hdf5) -> List[Path]:
+def _get_files(pth: Path, filt=h5py.is_hdf5) -> list[Path]:
     if pth.is_dir():
         return [fl for fl in pth.glob("*") if filt(fl)]
     else:
@@ -356,14 +356,14 @@ def process(
 
 
 def promote(
-    input_files: List[Path],
+    input_files: list[Path],
     nthreads: int,
     output_dir: Path,
-    output_fname: Optional[List[Path | None]],
-    step_cls: Type[levels._ReductionStep],
+    output_fname: list[Path | None] | None,
+    step_cls: type[levels._ReductionStep],
     settings: dict,
     clobber: bool,
-) -> List[Path]:
+) -> list[Path]:
     """Calibrate field data to produce CalibratedData files."""
     if not input_files:
         raise ValueError("No input files!")


### PR DESCRIPTION
This fixes performance issues that arise with processing data via the CLI.

There are three main fixes:

1. The `HDF5Object` objects are self-referencing and therefore do not automatically get garbage-collected. The reason for this is kinda complicated, and in this PR we don't fix the root problem (which might not be fixable at all), and instead use the method `clear()` on the object to clear away the data after each file has been processed. This was a memory leak, in that if we were running many files, the memory from each file would build up, instead of refreshing after each file. 
2. This `clear()` method is now also called for the *parent* object that is getting promoted. On a side note: for Raw data, we should expect a *doubling* of the data volume because the original data from the ACQ file is *copied* then written to a new file. It's not clear that this bad scaling would also happen for other levels, because they are able to read partially from H5 files.
3. I've added a check to the `process` sub-command that checks whether there is more than 4GB of RAM available and stops processing if so. It emits a warning when this happens, so that you can manually just kill the whole thing and start again with fewer threads, but it'll also by default just keep waiting until more memory becomes available before continuing.
