### PR TITLE
ci: add release-drafter config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+  - package-ecosystem: pip
+    directory: "/.github/workflows"
+    schedule:
+      interval: monthly
+  - package-ecosystem: pip
+    directory: "/docs"
+    schedule:
+      interval: monthly
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: "all"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,85 @@
+---
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# The repository labels will be automatically configured using this file and
+# the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: API Breaking
+  description: Breaking Changes
+  color: e305fc
+- name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+
+- name: "status: duplicate"
+  description: This issue or pull request already exists
+  color: d93f0b
+- name: "status: invalid"
+  description: Invalid issue or pull request
+  color: d93f0b
+- name: "status: requires discussion"
+  description: Issue requires further discussion before implementation
+  color: f71bd2
+- name: "status: requires research"
+  description: Issue requires further research before implementation
+  color: "d93f0b"
+- name: "status: wontfix"
+  description: Valid issue, but out of scope for future fixes
+  color: "d93f0b"
+
+- name: "type: maint: dependencies"
+  description: Pull requests that update a dependency file
+  color: "0366d6"
+- name: "type: maint: documentation"
+  description: Improvements or additions to documentation
+  color: "0075ca"
+- name: "type: maint: refactoring"
+  description: Refactoring
+  color: ef67c4
+- name: "type: maint: removal"
+  description: Removals and Deprecations
+  color: 9ae7ea
+- name: "type: maint: style"
+  description: Style
+  color: c120e5
+- name: "type: maint: build"
+  description: Build System and Dependencies
+  color: bfdadc
+
+- name: "type: accuracy"
+  description: "Enhancement that improves accuracy"
+  color: "bfd4f2"
+- name: "type: bug"
+  description: Something isn't working
+  color: d73a4a
+- name: "type: feature: ui"
+  description: New feature that adds functionality for the user
+  color: "0e8a16"
+- name: "type: feature: physical"
+  description: New feature that adds new analysis/physical model
+  color: "0e8a16"
+- name: "type: testing"
+  description: Testing improvements
+  color: b1fc6f
+- name: "type: performance: memory"
+  description: Performance improvements that reduce memory usage
+  color: "016175"
+- name: "type: performance: cpu"
+  description: Performance improvements that reduce walltime
+  color: "016175"
+- name: "type: ci"
+  description: Updates to CI (GH actions, RTD, etc.)
+  color: "000000"
+- name: "type: question"
+  description: A question about the code or documentation
+  color: d876e3
+
+- name: "priority: low"
+  description: Low priority
+  color: "BFD4F2"
+- name: "priority: medium"
+  description: Medium priority
+  color: "E99695"
+- name: "priority: high"
+  description: High priority
+  color: "B60205"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,77 @@
+# See https://github.com/marketplace/actions/release-drafter for configuration
+categories:
+  - title: ":boom: Breaking Changes"
+    labels:
+      - "API breaking"
+  - title: ":rocket: Features"
+    labels:
+      - "type: feature: ui"
+      - "type: feature: physical"
+  - title: ":fire: Removals and Deprecations"
+    labels:
+      - "type: maint: removal"
+  - title: ":beetle: Fixes"
+    labels:
+      - "type: bug"
+  - title: ":racehorse: Performance"
+    labels:
+      - "type: performance: memory"
+      - "type: performance: cpu"
+      - "type: accuracy"
+  - title: ":rotating_light: Testing"
+    labels:
+      - "type: testing"
+  - title: ":construction_worker: Continuous Integration"
+    labels:
+      - "type: ci"
+  - title: ":books: Documentation"
+    labels:
+      - "type: maint: documentation"
+  - title: ":hammer: Refactoring"
+    labels:
+      - "type: maint: refactoring"
+  - title: ":lipstick: Style"
+    labels:
+      - "type: maint: style"
+  - title: ":package: Dependencies"
+    labels:
+      - "type: maint: dependencies"
+      - "type: maint: build"
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+autolabeler:
+  - label: 'type: maint: documentation'
+    files:
+      - '*.md'
+      - '*.rst'
+      - 'docs/**/*'
+    branch:
+      - '/.*docs{0,1}.*/'
+  - label: 'type: bug'
+    branch:
+      - '/fix.*/'
+    title:
+      - '/fix/i'
+  - label: "type: maint: removal"
+    title:
+      - "/remove .*/i"
+  - label: "type: ci"
+    files:
+      - '.github/*'
+      - '.pre-commit-config.yaml'
+      - '.coveragrc'
+    branch:
+      - '/pre-commit-ci-update-config/'
+  - label: "type: maint: style"
+    files:
+      - '/pre-commit-ci-update-config/'
+  - label: "type: maint: refactoring"
+    title:
+      - "/.* refactor.*/i"
+
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
Simply adds some CI configuration for being able to update edges-analysis to the kind of releases we have on edges-io and edges-cal