### PR TITLE
fix: disable astropy IERS auto-download in tests to avoid flaky CI

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -95,6 +95,12 @@ jobs:
           path: "${{ needs.get_cache_data.outputs.usercache }}/**/*"
           key: "pooch-cache-${{ runner.os }}"
 
+      - name: Setup Astropy Download Cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.astropy/cache
+          key: "astropy-cache-${{ runner.os }}"
+
       - name: Run Tests
         run: |
           if [ "${{ matrix.testtype }}" = "warnfail" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from astropy import units as un
 from astropy.time import Time
+from astropy.utils import iers
 from pygsdata import GSData
 
 from edges import const
@@ -22,6 +23,13 @@ from edges.cal.receiver_cal import get_noise_wave_calibration_iterative
 from edges.frequencies import edges_raw_freqs
 from edges.io import calobsdef
 from edges.testing import create_mock_edges_data
+
+# Avoid flaky CI failures from astropy trying (and sometimes failing) to
+# download IERS Earth-rotation data. auto_max_age must also be disabled,
+# otherwise the bundled table is treated as too stale to interpolate from.
+iers.conf.auto_download = False
+iers.conf.auto_max_age = None
+iers.conf.iers_degraded_accuracy = "ignore"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- PR #283's `warnfail` CI job (`pytest -Werror`) was flaking whenever astropy's automatic IERS Earth-rotation data download failed or was rate-limited, since that failure surfaces as a warning which `-Werror` promotes to a test failure.
- Disable `astropy.utils.iers.conf.auto_download` in `tests/conftest.py` so tests never depend on network availability for this, and also disable `auto_max_age` (otherwise the bundled IERS-B table is treated as too stale to interpolate from, raising a `ValueError` in some alanmode tests) and set `iers_degraded_accuracy = "ignore"` to silence the accuracy-degraded warning.

## Test plan
- [x] `uv run pytest -Werror --no-cov -q` passes fully (673 passed, 32 skipped) with no network-dependent warnings/errors.
- [x] Confirmed the previous approach (only `auto_download = False`) caused new `ValueError`s in `tests/alanmode/test_edges3_alan_2022_316*.py` due to stale-table interpolation checks; fixed by also setting `auto_max_age = None`.
- [x] `pre-commit` (ruff lint/format) passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)